### PR TITLE
ci(timezone): remove timezone specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/node:8.11
-        environment:
-          TZ: "/usr/share/zoneinfo/America/Chicago"
     working_directory: ~/repo
-    environment:
-      TZ: "/usr/share/zoneinfo/America/Chicago"
     steps:
       - checkout
       - restore_cache:
@@ -19,7 +15,4 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
-      - run:
-          command: yarn run semantic-release
-          environment:
-            TZ: "/usr/share/zoneinfo/America/Chicago"
+      - run: yarn run semantic-release


### PR DESCRIPTION
semantic-release explicitly uses UTC so it doesn't matter